### PR TITLE
Fix project verification for multiple pages of projects

### DIFF
--- a/lib/errbit_gitlab_plugin/issue_tracker.rb
+++ b/lib/errbit_gitlab_plugin/issue_tracker.rb
@@ -126,7 +126,7 @@ module ErrbitGitlabPlugin
     #
     def gitlab_project_id(gitlab_url = options[:endpoint], token = options[:api_token], project = options[:path_with_namespace])
       @project_id ||= with_gitlab(gitlab_url, token) do |g|
-        g.projects.detect { |p| p.path_with_namespace == project }.try(:id)
+        g.projects.auto_paginate.detect { |p| p.path_with_namespace == project }.try(:id)
       end
     end
 

--- a/lib/errbit_gitlab_plugin/version.rb
+++ b/lib/errbit_gitlab_plugin/version.rb
@@ -1,3 +1,3 @@
 module ErrbitGitlabPlugin
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
My Gitlab instance has like 7 pages of results when polling the `/projects` endpoint, so verification fails if the project isn't on the first page. Luckily enough, the Gitlab gem supports paginating that endpoint automatically, so we just need to leverage that to fix.

I've deployed this change to my Errbit instance, and it does resolve the issue.
