### PR TITLE
Use project names instead of their ids when connecting to Gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This gem adds Gitlab issue tracker support to Errbit.
 
-Version 1.0 is compatible with Errbit 0.4.
+Version 1.0.x is compatible with Errbit >= 0.4.
 
 For (much) older versions of Errbit, try the 0.x gem versions or consider
 updating your Errbit installation

--- a/lib/errbit_gitlab_plugin/version.rb
+++ b/lib/errbit_gitlab_plugin/version.rb
@@ -1,3 +1,3 @@
 module ErrbitGitlabPlugin
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
See #5 

`Gitlab::Client::#project` is used directly when creating issues and validating the issue tracker instead of iterating over all existing projects.
