### PR TITLE
Use GitLab API v4 / add support for close_issue

### DIFF
--- a/errbit_gitlab_plugin.gemspec
+++ b/errbit_gitlab_plugin.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'errbit_plugin', '~> 0.5', '>= 0.5.0'
-  spec.add_runtime_dependency 'gitlab', '~> 3.4', '>= 3.4.0'
+  spec.add_runtime_dependency 'gitlab', '~> 4.17', '>= 4.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake', '~> 0'

--- a/errbit_gitlab_plugin.gemspec
+++ b/errbit_gitlab_plugin.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'errbit_plugin', '~> 0.5', '>= 0.5.0'
+  spec.add_runtime_dependency 'errbit_plugin', '~> 0.6', '>= 0.6.0'
   spec.add_runtime_dependency 'gitlab', '~> 4.17', '>= 4.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'

--- a/lib/errbit_gitlab_plugin/issue_tracker.rb
+++ b/lib/errbit_gitlab_plugin/issue_tracker.rb
@@ -124,6 +124,22 @@ module ErrbitGitlabPlugin
       format('%s/%s', url, ticket.iid)
     end
 
+    def close_issue(issue_link, closed_by = nil)
+      iid = issue_link.to_s.split("/").last.to_i
+
+      if iid.zero?
+        false
+      else
+        with_gitlab do |g|
+          g.close_issue(gitlab_project_id, iid)
+        end
+
+        true
+      end
+    rescue Gitlab::Error
+      false
+    end
+
     private
 
     #

--- a/lib/errbit_gitlab_plugin/issue_tracker.rb
+++ b/lib/errbit_gitlab_plugin/issue_tracker.rb
@@ -121,7 +121,7 @@ module ErrbitGitlabPlugin
         g.create_issue(gitlab_project_id, title, description: body, labels: options[:labels])
       end
 
-      format('%s/%s', url, ticket.id)
+      format('%s/%s', url, ticket.iid)
     end
 
     private
@@ -137,11 +137,11 @@ module ErrbitGitlabPlugin
     end
 
     #
-    # @return [String] a formatted APIv3 URL for the given +gitlab_url+
+    # @return [String] a formatted APIv4 URL for the given +gitlab_url+
     #
     def gitlab_endpoint(gitlab_url)
       uri = URI(gitlab_url)
-      format '%s://%s/api/v3', uri.scheme, uri.host
+      format '%s://%s/api/v4', uri.scheme, uri.host
     end
 
     #


### PR DESCRIPTION
Well pretty much as the title says.

I also very much want to click on my backtrace links and I'm thinking about adding this functionality to errbit_plugin rather than convoluting errbit itself. So expect to see me again 🙈

Edit: I should have mentioned that API v3 no longer works...

[5] pry(#<ErrbitGitlabPlugin::IssueTracker>)> p g.projects;
#<Gitlab::ObjectifiedHash:70345729807960 {hash: {"error"=>"API V3 is no longer supported. Use API V4 instead."}}
